### PR TITLE
Feature/fix bags/#3

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -60,4 +60,5 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.9.1'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     
     <application
+        android:name=".MainApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainApplication.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainApplication.kt
@@ -1,0 +1,6 @@
+package jp.co.yumemi.android.code_check
+
+import android.app.Application
+
+class MainApplication: Application() {
+}

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/repositoryDetail/RepositoryDetailFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/repositoryDetail/RepositoryDetailFragment.kt
@@ -43,7 +43,10 @@ class RepositoryDetailFragment : Fragment(R.layout.fragment_repository_detail) {
 
         val repository: Repository = args.repository
 
-        binding.ownerIconView.load(repository.ownerIconUrl)
+        binding.ownerIconView.load(repository.ownerIconUrl) {
+            R.drawable.jetbrains
+        }
+
         binding.nameView.text = repository.name
         binding.languageView.text = repository.language
         binding.starsView.text = context.getString(R.string.stargazers_count, repository.stargazersCount)

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/CustomAdapter.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/CustomAdapter.kt
@@ -1,5 +1,6 @@
 package jp.co.yumemi.android.code_check.ui.searchResult
 
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -16,10 +17,12 @@ class CustomAdapter(private val itemClickListener: OnItemClickListener)
     // 昔のデータと比較して違った場合のみRecyclerViewのItemを更新
     private class DiffCallback : DiffUtil.ItemCallback<Repository>(){
         override fun areItemsTheSame(oldItem: Repository, newItem: Repository): Boolean {
+            Log.d("CustomAdapter", "areItemsTheSame ${oldItem.name == newItem.name}")
             return oldItem.name == newItem.name
         }
 
         override fun areContentsTheSame(oldItem: Repository, newItem: Repository): Boolean {
+            Log.d("CustomAdapter", "areContentsTheSame ${oldItem.name == newItem.name}")
             return oldItem == newItem
         }
     }
@@ -43,6 +46,7 @@ class CustomAdapter(private val itemClickListener: OnItemClickListener)
         val repository: Repository = getItem(position)
         val repositoryNameView = holder.itemView.findViewById<View>(R.id.repositoryNameView) as TextView
         repositoryNameView.text = repository.name
+        Log.d("CustomAdapter", "repository.name ${repository.name}")
 
         // itemViewそのものを押した時リスナを通してイベントを送る
         holder.itemView.setOnClickListener{

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/CustomAdapter.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/CustomAdapter.kt
@@ -17,12 +17,10 @@ class CustomAdapter(private val itemClickListener: OnItemClickListener)
     // 昔のデータと比較して違った場合のみRecyclerViewのItemを更新
     private class DiffCallback : DiffUtil.ItemCallback<Repository>(){
         override fun areItemsTheSame(oldItem: Repository, newItem: Repository): Boolean {
-            Log.d("CustomAdapter", "areItemsTheSame ${oldItem.name == newItem.name}")
             return oldItem.name == newItem.name
         }
 
         override fun areContentsTheSame(oldItem: Repository, newItem: Repository): Boolean {
-            Log.d("CustomAdapter", "areContentsTheSame ${oldItem.name == newItem.name}")
             return oldItem == newItem
         }
     }
@@ -46,7 +44,6 @@ class CustomAdapter(private val itemClickListener: OnItemClickListener)
         val repository: Repository = getItem(position)
         val repositoryNameView = holder.itemView.findViewById<View>(R.id.repositoryNameView) as TextView
         repositoryNameView.text = repository.name
-        Log.d("CustomAdapter", "repository.name ${repository.name}")
 
         // itemViewそのものを押した時リスナを通してイベントを送る
         holder.itemView.setOnClickListener{

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/SearchResultFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/SearchResultFragment.kt
@@ -4,6 +4,7 @@
 package jp.co.yumemi.android.code_check.ui.searchResult
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -59,6 +60,7 @@ class SearchResultFragment: Fragment(R.layout.fragment_search_result){
 
         // repositoriesが更新されたらアダプタに渡す
         viewModel.repositories.observe(viewLifecycleOwner) {
+            Log.d("SearchResultFragment","observer $it")
             customAdapter.submitList(it)
         }
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/SearchResultFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/SearchResultFragment.kt
@@ -50,8 +50,10 @@ class SearchResultFragment: Fragment(R.layout.fragment_search_result){
             // IMEの検索ボタンに反応
             if (action == EditorInfo.IME_ACTION_SEARCH) {
                 // searchResultsの結果はviewModelのrepositoriesというLiveDataが持つ
-                val query = editText.text.toString()
-                viewModel.searchResults(query)
+                if (editText.text.isNotEmpty()) {
+                    val query = editText.text.toString()
+                    viewModel.searchResults(query)
+                }
                 true
             } else {
                 false

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/SearchResultFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/SearchResultFragment.kt
@@ -62,7 +62,6 @@ class SearchResultFragment: Fragment(R.layout.fragment_search_result){
 
         // repositoriesが更新されたらアダプタに渡す
         viewModel.repositories.observe(viewLifecycleOwner) {
-            Log.d("SearchResultFragment","observer $it")
             customAdapter.submitList(it)
         }
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/SearchResultFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/SearchResultFragment.kt
@@ -12,6 +12,7 @@ import androidx.fragment.app.Fragment
 import androidx.navigation.NavDirections
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.*
+import jp.co.yumemi.android.code_check.MainApplication
 import jp.co.yumemi.android.code_check.R
 import jp.co.yumemi.android.code_check.databinding.FragmentSearchResultBinding
 import jp.co.yumemi.android.code_check.model.Repository
@@ -34,7 +35,7 @@ class SearchResultFragment: Fragment(R.layout.fragment_search_result){
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val viewModel = SearchResultViewModel(requireContext())
+        val viewModel = SearchResultViewModel(requireActivity().application as MainApplication)
         val layoutManager = LinearLayoutManager(requireContext())
         val dividerItemDecoration = DividerItemDecoration(requireContext(), layoutManager.orientation)
         val customAdapter = CustomAdapter(object : CustomAdapter.OnItemClickListener{

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/SearchResultViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/SearchResultViewModel.kt
@@ -4,6 +4,7 @@
 package jp.co.yumemi.android.code_check.ui.searchResult
 
 import android.content.Context
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -44,6 +45,7 @@ class SearchResultViewModel(val app: MainApplication) : ViewModel() {
 
             for (i in 0 until jsonItems.length()) {
                 val jsonItem = jsonItems.optJSONObject(i)
+                Log.d("SearchResultViewModel","$jsonItem")
                 val name = jsonItem.optString("full_name")
                 val ownerIconUrl = jsonItem.optString("owner.avatar_url")
                 val language = jsonItem.optString("language")

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/SearchResultViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/SearchResultViewModel.kt
@@ -13,6 +13,7 @@ import io.ktor.client.call.*
 import io.ktor.client.engine.android.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
+import jp.co.yumemi.android.code_check.MainApplication
 import jp.co.yumemi.android.code_check.R
 import jp.co.yumemi.android.code_check.TopActivity.Companion.lastSearchDate
 import jp.co.yumemi.android.code_check.model.Repository
@@ -21,7 +22,7 @@ import org.json.JSONArray
 import org.json.JSONObject
 import java.util.*
 
-class SearchResultViewModel(val context: Context) : ViewModel() {
+class SearchResultViewModel(val app: MainApplication) : ViewModel() {
 
     // APIを叩いた結果はList<Repository>に変換されここに入る
     private val _repositories = MutableLiveData<List<Repository>>(listOf())
@@ -55,7 +56,7 @@ class SearchResultViewModel(val context: Context) : ViewModel() {
                     Repository(
                         name = name,
                         ownerIconUrl = ownerIconUrl,
-                        language = context.getString(R.string.written_language, language),
+                        language = app.applicationContext.getString(R.string.written_language, language),
                         stargazersCount = stargazersCount,
                         watchersCount = watchersCount,
                         forksCount = forksCount,

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/SearchResultViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/SearchResultViewModel.kt
@@ -47,7 +47,7 @@ class SearchResultViewModel(val app: MainApplication) : ViewModel() {
                 val jsonItem = jsonItems.optJSONObject(i)
                 Log.d("SearchResultViewModel","$jsonItem")
                 val name = jsonItem.optString("full_name")
-                val ownerIconUrl = jsonItem.optString("owner.avatar_url")
+                val ownerIconUrl = jsonItem.optJSONObject("owner")?.optString("avatar_url") ?: ""
                 val language = jsonItem.optString("language")
                 val stargazersCount = jsonItem.optLong("stargazers_count")
                 val watchersCount = jsonItem.optLong("watchers_count")

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/SearchResultViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/SearchResultViewModel.kt
@@ -45,7 +45,6 @@ class SearchResultViewModel(val app: MainApplication) : ViewModel() {
 
             for (i in 0 until jsonItems.length()) {
                 val jsonItem = jsonItems.optJSONObject(i)
-                Log.d("SearchResultViewModel","$jsonItem")
                 val name = jsonItem.optString("full_name")
                 val ownerIconUrl = jsonItem.optJSONObject("owner")?.optString("avatar_url") ?: ""
                 val language = jsonItem.optString("language")


### PR DESCRIPTION
Close #3

why
- 特定の操作でクラッシュ、画像が表示されないなどのエラーがあった。

what
- 検索欄に何も入力しないとクラッシュするのをしないようにした。(a8c83bb)
- ViewModelの使用するContextをFragmentのContextではなくapplicationのapplicationContextに変更 (7e42532)
- 画像が表示されるように (95d8ee0)

ex
- `[VRI[TopActivity]#0](f:0,a:2) Faking releaseBufferCallback from transactionCompleteCallback`
  - 結論から言うと修正しなくても良いができるならした方がいいもの
  - これはbuffer callbackが解放されない問題を偽のイベントで解放している時に出されるログ
  - これは安全な回避策と言われている