### PR TITLE
Feature/upgrade library/#13

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,7 +40,7 @@ android {
 dependencies {
 
     // 予定: 1.9.0 依存: Kotlin 1.7.10
-    implementation 'androidx.core:core-ktx:1.6.0'
+    implementation 'androidx.core:core-ktx:1.9.0'
     // 予定: 1.6.1 依存: Kotlin 1.7.10, core 1.9.0, lifecycle 2.5.1
     implementation 'androidx.appcompat:appcompat:1.3.1'
     // 予定: 1.8.0 依存: core 1.6.0, lifecycle 2.0.0, recyclerview 1.0.0

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -67,7 +67,7 @@ dependencies {
 
     testImplementation 'junit:junit:4.13.2'
     // 予定: 1.1.5
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     // 予定: 3.5.1
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.9.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -70,5 +70,4 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     // 予定: 3.5.1
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
-    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.9.1'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,8 +49,8 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.3.1'
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
 
-    implementation 'androidx.navigation:navigation-fragment-ktx:2.3.5'
-    implementation 'androidx.navigation:navigation-ui-ktx:2.3.5'
+    implementation 'androidx.navigation:navigation-fragment-ktx:2.5.3'
+    implementation 'androidx.navigation:navigation-ui-ktx:2.5.3'
 
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.2'
     implementation 'io.ktor:ktor-client-android:1.6.4'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -50,9 +50,10 @@ dependencies {
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
 
     // 予定: 2.5.1
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.1'
-    implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.3.1'
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
+    ext.lifecycle_ver = '2.5.1'
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_ver"
+    implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_ver"
+    implementation "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycle_ver"
 
     implementation 'androidx.navigation:navigation-fragment-ktx:2.5.3'
     implementation 'androidx.navigation:navigation-ui-ktx:2.5.3'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     implementation 'io.ktor:ktor-client-android:1.6.4'
 
     // 予定: 2.2.2
-    implementation 'io.coil-kt:coil:1.3.2'
+    implementation 'io.coil-kt:coil:2.2.2'
 
     testImplementation 'junit:junit:4.13.2'
     // 予定: 1.1.5

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,12 +7,12 @@ plugins {
 }
 
 android {
-    compileSdk 31
+    compileSdk 33
 
     defaultConfig {
         applicationId "jp.co.yumemi.android.codecheck"
         minSdk 23
-        targetSdk 31
+        targetSdk 33
         versionCode 1
         versionName "1.0"
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -69,6 +69,6 @@ dependencies {
     // 予定: 1.1.5
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     // 予定: 3.5.1
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
     debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.9.1'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     // 予定: 1.9.0 依存: Kotlin 1.7.10
     implementation 'androidx.core:core-ktx:1.9.0'
     // 予定: 1.6.1 依存: Kotlin 1.7.10, core 1.9.0, lifecycle 2.5.1
-    implementation 'androidx.appcompat:appcompat:1.3.1'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
     // 予定: 1.8.0 依存: core 1.6.0, lifecycle 2.0.0, recyclerview 1.0.0
     implementation 'com.google.android.material:material:1.4.0'
     // 予定: 2.1.4 依存: core 1.3.2

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,17 +39,12 @@ android {
 
 dependencies {
 
-    // 予定: 1.9.0 依存: Kotlin 1.7.10
     implementation 'androidx.core:core-ktx:1.9.0'
-    // 予定: 1.6.1 依存: Kotlin 1.7.10, core 1.9.0, lifecycle 2.5.1
     implementation 'androidx.appcompat:appcompat:1.6.1'
-    // 予定: 1.8.0 依存: core 1.6.0, lifecycle 2.0.0, recyclerview 1.0.0
     implementation 'com.google.android.material:material:1.8.0'
-    // 予定: 2.1.4 依存: core 1.3.2
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
 
-    // 予定: 2.5.1
     ext.lifecycle_ver = '2.5.1'
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_ver"
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_ver"
@@ -58,16 +53,12 @@ dependencies {
     implementation 'androidx.navigation:navigation-fragment-ktx:2.5.3'
     implementation 'androidx.navigation:navigation-ui-ktx:2.5.3'
 
-    // 予定: 1.6.4
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4'
     implementation 'io.ktor:ktor-client-android:1.6.4'
 
-    // 予定: 2.2.2
     implementation 'io.coil-kt:coil:2.2.2'
 
     testImplementation 'junit:junit:4.13.2'
-    // 予定: 1.1.5
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-    // 予定: 3.5.1
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,12 +39,17 @@ android {
 
 dependencies {
 
+    // 予定: 1.9.0 依存: Kotlin 1.7.10
     implementation 'androidx.core:core-ktx:1.6.0'
+    // 予定: 1.6.1 依存: Kotlin 1.7.10, core 1.9.0, lifecycle 2.5.1
     implementation 'androidx.appcompat:appcompat:1.3.1'
+    // 予定: 1.8.0 依存: core 1.6.0, lifecycle 2.0.0, recyclerview 1.0.0
     implementation 'com.google.android.material:material:1.4.0'
+    // 予定: 2.1.4 依存: core 1.3.2
     implementation 'androidx.constraintlayout:constraintlayout:2.1.1'
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
 
+    // 予定: 2.5.1
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.1'
     implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.3.1'
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
@@ -52,13 +57,17 @@ dependencies {
     implementation 'androidx.navigation:navigation-fragment-ktx:2.5.3'
     implementation 'androidx.navigation:navigation-ui-ktx:2.5.3'
 
+    // 予定: 1.6.4
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.2'
     implementation 'io.ktor:ktor-client-android:1.6.4'
 
+    // 予定: 2.2.2
     implementation 'io.coil-kt:coil:1.3.2'
 
     testImplementation 'junit:junit:4.13.2'
+    // 予定: 1.1.5
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    // 予定: 3.5.1
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.9.1'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     implementation 'androidx.navigation:navigation-ui-ktx:2.5.3'
 
     // 予定: 1.6.4
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.2'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4'
     implementation 'io.ktor:ktor-client-android:1.6.4'
 
     // 予定: 2.2.2

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     // 予定: 1.6.1 依存: Kotlin 1.7.10, core 1.9.0, lifecycle 2.5.1
     implementation 'androidx.appcompat:appcompat:1.6.1'
     // 予定: 1.8.0 依存: core 1.6.0, lifecycle 2.0.0, recyclerview 1.0.0
-    implementation 'com.google.android.material:material:1.4.0'
+    implementation 'com.google.android.material:material:1.8.0'
     // 予定: 2.1.4 依存: core 1.3.2
     implementation 'androidx.constraintlayout:constraintlayout:2.1.1'
     implementation 'androidx.recyclerview:recyclerview:1.2.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     // 予定: 1.8.0 依存: core 1.6.0, lifecycle 2.0.0, recyclerview 1.0.0
     implementation 'com.google.android.material:material:1.8.0'
     // 予定: 2.1.4 依存: core 1.3.2
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.1'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
 
     // 予定: 2.5.1

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:7.4.2'
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21'
-        classpath 'androidx.navigation:navigation-safe-args-gradle-plugin:2.4.1'
+        classpath 'androidx.navigation:navigation-safe-args-gradle-plugin:2.5.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -5,9 +5,9 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.3'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.31"
-        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.3.5"
+        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21'
+        classpath 'androidx.navigation:navigation-safe-args-gradle-plugin:2.4.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.4.2'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.0'
         classpath 'androidx.navigation:navigation-safe-args-gradle-plugin:2.5.3'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,3 +19,4 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+org.gradle.unsafe.configuration-cache=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Aug 23 19:11:29 JST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Close #13 

### 注意
本ブランチの多くのコミットにはDescriptionが書かれています。
主にバージョンアップの変更点が書かれた公式ドキュメントやmovenリポジトリのリンクがあります。
GradleのインストールにJavaの最新バージョンが必要になる可能性があります。

### why
- Gradleやライブラリのバージョンが古くなっていた

### what
バージョンアップした

- Gradle
  - 7.0.2 → 7.4.2
- Kotlin 
  - 1.6.2 → 1.8.0
- navigation-safe-args-gradle-plugin
  - 2.4.1 → 2.5.3

- androidx.core:core-ktx:1.6.0
  - 1.6.0 → 1.9.0
  - 依存: Kotlin 1.7.10
- androidx.appcompat:appcompat:1.3.1
  - 1.3.1 → 1.6.1
  - 依存: Kotlin 1.7.10, core 1.9.0, lifecycle 2.5.1
- com.google.android.material:material:1.4.0
  - 1.4.0 → 1.8.0
  - 依存: core 1.6.0, lifecycle 2.0.0, recyclerview 1.0.0
- androidx.constraintlayout:constraintlayout:2.1.1
  - 2.1.1 → 2.1.4
  - 依存: core 1.3.2
- androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.1
- androidx.lifecycle:lifecycle-livedata-ktx:2.3.1
- androidx.lifecycle:lifecycle-runtime-ktx:2.3.1
  - 2.3.1 → 2.5.1
- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.2
  - 1.5.2 → 1.6.4
- io.coil-kt:coil:1.3.2
  - 1.3.2 → 2.2.2
- androidx.test.ext:junit:1.1.3
  - 1.1.3 → 1.1.5
- androidx.test.espresso:espresso-core:3.4.0
  - 3.4.0 → 3.5.1