### PR TITLE
Feature/refactor fat fragment/#4

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/TopActivity.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/TopActivity.kt
@@ -8,7 +8,4 @@ import java.util.*
 
 class TopActivity : AppCompatActivity(R.layout.activity_top) {
 
-    companion object {
-        lateinit var lastSearchDate: Date
-    }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/TopActivity.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/TopActivity.kt
@@ -4,7 +4,6 @@
 package jp.co.yumemi.android.code_check
 
 import androidx.appcompat.app.AppCompatActivity
-import java.util.*
 
 class TopActivity : AppCompatActivity(R.layout.activity_top) {
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/api/GithubApi.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/api/GithubApi.kt
@@ -1,0 +1,55 @@
+package jp.co.yumemi.android.code_check.api
+
+import androidx.lifecycle.MutableLiveData
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.engine.android.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import jp.co.yumemi.android.code_check.model.Repository
+import org.json.JSONArray
+import org.json.JSONObject
+
+class GithubApi {
+    companion object {
+        suspend fun searchRepositories(
+            query: String,
+            result: MutableLiveData<List<Repository>>,
+        ) {
+            val client = HttpClient(Android)
+
+            val response: HttpResponse = client.get("https://api.github.com/search/repositories") {
+                header("Accept", "application/vnd.github.v3+json")
+                parameter("q", query)
+            }
+
+            val jsonBody = JSONObject(response.receive<String>())
+            val jsonItems = jsonBody.optJSONArray("items") ?: JSONArray()
+            val repositories = mutableListOf<Repository>()
+
+            for (i in 0 until jsonItems.length()) {
+                val jsonItem = jsonItems.optJSONObject(i)
+                val name = jsonItem.optString("full_name")
+                val ownerIconUrl = jsonItem.optJSONObject("owner")?.optString("avatar_url") ?: ""
+                val language = jsonItem.optString("language")
+                val stargazersCount = jsonItem.optLong("stargazers_count")
+                val watchersCount = jsonItem.optLong("watchers_count")
+                val forksCount = jsonItem.optLong("forks_count")
+                val openIssuesCount = jsonItem.optLong("open_issues_count")
+
+                repositories.add(
+                    Repository(
+                        name = name,
+                        ownerIconUrl = ownerIconUrl,
+                        language = language,
+                        stargazersCount = stargazersCount,
+                        watchersCount = watchersCount,
+                        forksCount = forksCount,
+                        openIssuesCount = openIssuesCount
+                    )
+                )
+            }
+            result.postValue(repositories)
+        }
+    }
+}

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/repositoryDetail/RepositoryDetailFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/repositoryDetail/RepositoryDetailFragment.kt
@@ -5,7 +5,6 @@ package jp.co.yumemi.android.code_check.ui.repositoryDetail
 
 import android.content.Context
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/repositoryDetail/RepositoryDetailFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/repositoryDetail/RepositoryDetailFragment.kt
@@ -45,7 +45,7 @@ class RepositoryDetailFragment : Fragment(R.layout.fragment_repository_detail) {
         }
 
         binding.nameView.text = repository.name
-        binding.languageView.text = repository.language
+        binding.languageView.text = context.getString(R.string.written_language, repository.language)
         binding.starsView.text = context.getString(R.string.stargazers_count, repository.stargazersCount)
         binding.watchersView.text = context.getString(R.string.watchers_count, repository.watchersCount)
         binding.forksView.text = context.getString(R.string.forks_count, repository.forksCount)

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/repositoryDetail/RepositoryDetailFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/repositoryDetail/RepositoryDetailFragment.kt
@@ -13,7 +13,6 @@ import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.navArgs
 import coil.load
 import jp.co.yumemi.android.code_check.R
-import jp.co.yumemi.android.code_check.TopActivity.Companion.lastSearchDate
 import jp.co.yumemi.android.code_check.databinding.FragmentRepositoryDetailBinding
 import jp.co.yumemi.android.code_check.model.Repository
 
@@ -38,8 +37,6 @@ class RepositoryDetailFragment : Fragment(R.layout.fragment_repository_detail) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
-        Log.d("検索した日時", lastSearchDate.toString())
 
         val repository: Repository = args.repository
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/CustomAdapter.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/CustomAdapter.kt
@@ -1,6 +1,5 @@
 package jp.co.yumemi.android.code_check.ui.searchResult
 
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/SearchResultFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/SearchResultFragment.kt
@@ -52,7 +52,7 @@ class SearchResultFragment: Fragment(R.layout.fragment_search_result){
                 // searchResultsの結果はviewModelのrepositoriesというLiveDataが持つ
                 if (editText.text.isNotEmpty()) {
                     val query = editText.text.toString()
-                    viewModel.searchResults(query)
+                    viewModel.searchRepositories(query)
                 }
                 true
             } else {

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/SearchResultFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/SearchResultFragment.kt
@@ -4,7 +4,6 @@
 package jp.co.yumemi.android.code_check.ui.searchResult
 
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/SearchResultViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/SearchResultViewModel.kt
@@ -16,7 +16,6 @@ import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import jp.co.yumemi.android.code_check.MainApplication
 import jp.co.yumemi.android.code_check.R
-import jp.co.yumemi.android.code_check.TopActivity.Companion.lastSearchDate
 import jp.co.yumemi.android.code_check.model.Repository
 import kotlinx.coroutines.launch
 import org.json.JSONArray
@@ -65,7 +64,6 @@ class SearchResultViewModel(val app: MainApplication) : ViewModel() {
                     )
                 )
             }
-            lastSearchDate = Date()
             _repositories.postValue(repositories)
         }
     }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/SearchResultViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/SearchResultViewModel.kt
@@ -3,25 +3,14 @@
  */
 package jp.co.yumemi.android.code_check.ui.searchResult
 
-import android.content.Context
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import io.ktor.client.*
-import io.ktor.client.call.*
-import io.ktor.client.engine.android.*
-import io.ktor.client.request.*
-import io.ktor.client.statement.*
 import jp.co.yumemi.android.code_check.MainApplication
-import jp.co.yumemi.android.code_check.R
 import jp.co.yumemi.android.code_check.api.GithubApi
 import jp.co.yumemi.android.code_check.model.Repository
 import kotlinx.coroutines.launch
-import org.json.JSONArray
-import org.json.JSONObject
-import java.util.*
 
 class SearchResultViewModel(val app: MainApplication) : ViewModel() {
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/SearchResultViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/SearchResultViewModel.kt
@@ -30,9 +30,9 @@ class SearchResultViewModel(val app: MainApplication) : ViewModel() {
     val repositories: LiveData<List<Repository>> = _repositories
 
     // githubAPIを叩き、検索結果をLiveDataに投げる
-    fun searchResults(inputText: String) {
+    fun searchRepositories(query: String) {
         viewModelScope.launch {
-            GithubApi.searchRepositories(inputText, _repositories)
+            GithubApi.searchRepositories(query, _repositories)
         }
     }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/SearchResultViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/SearchResultViewModel.kt
@@ -16,6 +16,7 @@ import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import jp.co.yumemi.android.code_check.MainApplication
 import jp.co.yumemi.android.code_check.R
+import jp.co.yumemi.android.code_check.api.GithubApi
 import jp.co.yumemi.android.code_check.model.Repository
 import kotlinx.coroutines.launch
 import org.json.JSONArray
@@ -31,40 +32,7 @@ class SearchResultViewModel(val app: MainApplication) : ViewModel() {
     // githubAPIを叩き、検索結果をLiveDataに投げる
     fun searchResults(inputText: String) {
         viewModelScope.launch {
-            val client = HttpClient(Android)
-
-            val response: HttpResponse = client.get("https://api.github.com/search/repositories") {
-                header("Accept", "application/vnd.github.v3+json")
-                parameter("q", inputText)
-            }
-
-            val jsonBody = JSONObject(response.receive<String>())
-            val jsonItems = jsonBody.optJSONArray("items") ?: JSONArray()
-            val repositories = mutableListOf<Repository>()
-
-            for (i in 0 until jsonItems.length()) {
-                val jsonItem = jsonItems.optJSONObject(i)
-                val name = jsonItem.optString("full_name")
-                val ownerIconUrl = jsonItem.optJSONObject("owner")?.optString("avatar_url") ?: ""
-                val language = jsonItem.optString("language")
-                val stargazersCount = jsonItem.optLong("stargazers_count")
-                val watchersCount = jsonItem.optLong("watchers_count")
-                val forksCount = jsonItem.optLong("forks_count")
-                val openIssuesCount = jsonItem.optLong("open_issues_count")
-
-                repositories.add(
-                    Repository(
-                        name = name,
-                        ownerIconUrl = ownerIconUrl,
-                        language = app.applicationContext.getString(R.string.written_language, language),
-                        stargazersCount = stargazersCount,
-                        watchersCount = watchersCount,
-                        forksCount = forksCount,
-                        openIssuesCount = openIssuesCount
-                    )
-                )
-            }
-            _repositories.postValue(repositories)
+            GithubApi.searchRepositories(inputText, _repositories)
         }
     }
 }


### PR DESCRIPTION
Close #4 

### why
- Fragmentが必要以上の役割を持っていた。
  - 具体的にはFragmentのViewModelがApiを叩いていた。

### what
- ApiパッケージとGithubApiクラスを作成し、Fragmentはそれを呼び出すだけにした。

### ex
- MainActivityにあった最終検索日時を格納する変数を以下の理由で削除しました (5add4cf)
  - ログ確認にしか使用していなかったため（アプリの動作として必要なかった）
  - GithubApiクラスを使用するにあたって、その役割からActivityクラスの変数を操作するのは不適切だったため。