### PR TITLE
Feature/fix bugs/#18

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/SearchResultFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/SearchResultFragment.kt
@@ -49,7 +49,7 @@ class SearchResultFragment: Fragment(R.layout.fragment_search_result){
             // IMEの検索ボタンに反応
             if (action == EditorInfo.IME_ACTION_SEARCH) {
                 // searchResultsの結果はviewModelのrepositoriesというLiveDataが持つ
-                if (editText.text.isNotEmpty()) {
+                if (viewModel.validationCheck(editText.text)) {
                     val query = editText.text.toString()
                     viewModel.searchRepositories(query)
                 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/SearchResultViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/SearchResultViewModel.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import jp.co.yumemi.android.code_check.MainApplication
+import jp.co.yumemi.android.code_check.R
 import jp.co.yumemi.android.code_check.api.GithubApi
 import jp.co.yumemi.android.code_check.model.Repository
 import kotlinx.coroutines.launch
@@ -31,7 +32,7 @@ class SearchResultViewModel(val app: MainApplication) : ViewModel() {
         if (query.isBlank()) {
             Toast.makeText(
                 app.applicationContext,
-                "検索欄に文字を入力してください",
+                app.applicationContext.getString(R.string.error_no_query),
                 Toast.LENGTH_SHORT
             ).show()
             return false
@@ -40,7 +41,7 @@ class SearchResultViewModel(val app: MainApplication) : ViewModel() {
         if (query.length > 255) {
             Toast.makeText(
                 app.applicationContext,
-                "文字が長すぎます",
+                app.applicationContext.getString(R.string.error_too_long_query),
                 Toast.LENGTH_SHORT
             ).show()
             return false

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/SearchResultViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/SearchResultViewModel.kt
@@ -25,7 +25,7 @@ class SearchResultViewModel(val app: MainApplication) : ViewModel() {
         }
     }
 
-    fun validationCheck (query: String): Boolean {
+    fun validationCheck (query: CharSequence): Boolean {
         // null もしくは 空白のみ
         if (query.isBlank()) {
             return false

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/SearchResultViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/SearchResultViewModel.kt
@@ -3,6 +3,7 @@
  */
 package jp.co.yumemi.android.code_check.ui.searchResult
 
+import android.widget.Toast
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -28,10 +29,20 @@ class SearchResultViewModel(val app: MainApplication) : ViewModel() {
     fun validationCheck (query: CharSequence): Boolean {
         // null もしくは 空白のみ
         if (query.isBlank()) {
+            Toast.makeText(
+                app.applicationContext,
+                "検索欄に文字を入力してください",
+                Toast.LENGTH_SHORT
+            ).show()
             return false
         }
         // 256文字以上の時
         if (query.length > 255) {
+            Toast.makeText(
+                app.applicationContext,
+                "文字が長すぎます",
+                Toast.LENGTH_SHORT
+            ).show()
             return false
         }
         return true

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/SearchResultViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/SearchResultViewModel.kt
@@ -24,4 +24,16 @@ class SearchResultViewModel(val app: MainApplication) : ViewModel() {
             GithubApi.searchRepositories(query, _repositories)
         }
     }
+
+    fun validationCheck (query: String): Boolean {
+        // null もしくは 空白のみ
+        if (query.isBlank()) {
+            return false
+        }
+        // 256文字以上の時
+        if (query.length > 255) {
+            return false
+        }
+        return true
+    }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,4 +6,6 @@
     <string name="watchers_count">%d watchers</string>
     <string name="forks_count">%d forks</string>
     <string name="open_issues_count">%d open issues</string>
+    <string name="error_no_query">検索欄に文字を入力してください</string>
+    <string name="error_too_long_query">文字が長すぎます</string>
 </resources>


### PR DESCRIPTION
Close #18 

why
- 空白のみを入力し、検索した結果クラッシュした。
- その他様々な検索を試しクラッシュする可能性を減らす。

what
- 幾つかの検索を試し、エラーが出る場合は検索をせずユーザにトーストを発行するようにした。
  - 空白（スペース）のみ：エラーが出るため検索をせずトーストを発行
  - 入力なし：エラーが出るため検索をせずトーストを発行
  - 絵文字：エラーなし