### PR TITLE
Feature/remember last search/#21

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainApplication.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainApplication.kt
@@ -1,6 +1,18 @@
 package jp.co.yumemi.android.code_check
 
 import android.app.Application
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import jp.co.yumemi.android.code_check.model.Repository
 
 class MainApplication: Application() {
+
+    // APIを叩いた結果はList<Repository>に変換されここに入る
+    private val _repositories = MutableLiveData<List<Repository>>(listOf())
+    val repositories: LiveData<List<Repository>> = _repositories
+
+    fun setRepositories(input: List<Repository>) {
+        _repositories.postValue(input)
+    }
+
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/api/GithubApi.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/api/GithubApi.kt
@@ -12,10 +12,8 @@ import org.json.JSONObject
 
 class GithubApi {
     companion object {
-        suspend fun searchRepositories(
-            query: String,
-            result: MutableLiveData<List<Repository>>,
-        ): List<Repository> {
+        suspend fun searchRepositories(query: String, ): List<Repository> {
+
             val client = HttpClient(Android)
 
             val response: HttpResponse = client.get("https://api.github.com/search/repositories") {
@@ -49,7 +47,7 @@ class GithubApi {
                     )
                 )
             }
-            result.postValue(repositories)
+
             return repositories.toList()
         }
     }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/api/GithubApi.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/api/GithubApi.kt
@@ -15,7 +15,7 @@ class GithubApi {
         suspend fun searchRepositories(
             query: String,
             result: MutableLiveData<List<Repository>>,
-        ) {
+        ): List<Repository> {
             val client = HttpClient(Android)
 
             val response: HttpResponse = client.get("https://api.github.com/search/repositories") {
@@ -50,6 +50,7 @@ class GithubApi {
                 )
             }
             result.postValue(repositories)
+            return repositories.toList()
         }
     }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/api/GithubApi.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/api/GithubApi.kt
@@ -1,6 +1,5 @@
 package jp.co.yumemi.android.code_check.api
 
-import androidx.lifecycle.MutableLiveData
 import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.engine.android.*

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/SearchResultFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/SearchResultFragment.kt
@@ -61,8 +61,8 @@ class SearchResultFragment: Fragment(R.layout.fragment_search_result){
             }
         }
 
-        // repositoriesが更新されたらアダプタに渡す
-        viewModel.repositories.observe(viewLifecycleOwner) {
+        // MainApplicationのrepositoriesが更新されたらアダプタに渡す
+        app.repositories.observe(viewLifecycleOwner) {
             customAdapter.submitList(it)
         }
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/SearchResultFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/SearchResultFragment.kt
@@ -22,20 +22,22 @@ class SearchResultFragment: Fragment(R.layout.fragment_search_result){
     private var _binding: FragmentSearchResultBinding? = null
     private val binding get() = _binding!!
 
+    lateinit var app: MainApplication
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
         _binding = FragmentSearchResultBinding.inflate(inflater, container, false)
-
+        app = requireActivity().application as MainApplication
         return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val viewModel = SearchResultViewModel(requireActivity().application as MainApplication)
+        val viewModel = SearchResultViewModel(app)
         val layoutManager = LinearLayoutManager(requireContext())
         val dividerItemDecoration = DividerItemDecoration(requireContext(), layoutManager.orientation)
         val customAdapter = CustomAdapter(object : CustomAdapter.OnItemClickListener{

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/SearchResultViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/SearchResultViewModel.kt
@@ -23,7 +23,7 @@ class SearchResultViewModel(val app: MainApplication) : ViewModel() {
     // githubAPIを叩き、検索結果をLiveDataに投げる
     fun searchRepositories(query: String) {
         viewModelScope.launch {
-            GithubApi.searchRepositories(query, _repositories)
+            app.setRepositories(GithubApi.searchRepositories(query))
         }
     }
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/SearchResultViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/searchResult/SearchResultViewModel.kt
@@ -4,21 +4,14 @@
 package jp.co.yumemi.android.code_check.ui.searchResult
 
 import android.widget.Toast
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import jp.co.yumemi.android.code_check.MainApplication
 import jp.co.yumemi.android.code_check.R
 import jp.co.yumemi.android.code_check.api.GithubApi
-import jp.co.yumemi.android.code_check.model.Repository
 import kotlinx.coroutines.launch
 
 class SearchResultViewModel(val app: MainApplication) : ViewModel() {
-
-    // APIを叩いた結果はList<Repository>に変換されここに入る
-    private val _repositories = MutableLiveData<List<Repository>>(listOf())
-    val repositories: LiveData<List<Repository>> = _repositories
 
     // githubAPIを叩き、検索結果をLiveDataに投げる
     fun searchRepositories(query: String) {


### PR DESCRIPTION
Close #21 

why
- 詳細画面から検索画面に戻ると検索結果が破棄されて不便だった

what
- 詳細画面から検索画面に戻っても検索結果が破棄されなくなった
<img src="https://user-images.githubusercontent.com/86464601/223667279-2c2e74fe-0212-4ac8-acaa-7189a8c79f43.gif" width="200px">

Details
- 検索結果をViewModelではなくMainApplicationが保持するように変更